### PR TITLE
Move D-Bus conf file to share/dbus-1/system.d

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -70,7 +70,7 @@ AC_ARG_WITH(dbus-sys, [  --with-dbus-sys=<dir>   where D-BUS system.d directory 
 if ! test -z "$with_dbus_sys" ; then
     DBUS_SYS_DIR="$with_dbus_sys"
 else
-    DBUS_SYS_DIR="$sysconfdir/dbus-1/system.d"
+    DBUS_SYS_DIR="$datadir/dbus-1/system.d"
 fi
 AC_SUBST(DBUS_SYS_DIR)
 


### PR DESCRIPTION
Since D-Bus 1.9.18 configuration files installed by third-party should
go in share/dbus-1/system.d. The old location is for sysadmin overrides.

Actually for a nixpkgs precedent https://github.com/NixOS/nixpkgs/pull/68875.