### PR TITLE
add missing stdlib.h

### DIFF
--- a/src/libnixxml/nixxml-generate-env.c
+++ b/src/libnixxml/nixxml-generate-env.c
@@ -19,6 +19,7 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#include <stdlib.h>
 #include "nixxml-generate-env.h"
 
 #define BUFFER_SIZE 50

--- a/src/libnixxml/nixxml-parse-generic.c
+++ b/src/libnixxml/nixxml-parse-generic.c
@@ -19,6 +19,7 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#include <stdlib.h>
 #include "nixxml-parse-generic.h"
 
 #define TRUE 1


### PR DESCRIPTION
fix implicit function declaration

```console
nixxml-generate-env.c:97:9: error: call to undeclared library function 'free' with type 'void (void *)'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
        free(array);
        ^
nixxml-parse-generic.c:29:39: error: call to undeclared library function 'malloc' with type 'void *(unsigned long)'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
    NixXML_Node *node = (NixXML_Node*)malloc(sizeof(NixXML_Node));
                                      ^
```